### PR TITLE
Add MCP registry publishing configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI and MCP Registry
 on:
   release:
     types: [published]
@@ -7,6 +7,9 @@ jobs:
   publish:
     name: Release build and publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -29,3 +32,22 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
+
+      - name: Install MCP Publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.1.0/mcp-publisher_1.1.0_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Validate server.json
+        run: |
+          # Install ajv-cli for JSON schema validation
+          npm install -g ajv-cli
+          # Download and validate server.json against MCP schema
+          curl -o server.schema.json https://static.modelcontextprotocol.io/schemas/2025-09-16/server.schema.json
+          ajv validate -s server.schema.json -d server.json --strict=false
+
+      - name: Login to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,54 @@
+{
+  "name": "io.github.appwrite/mcp-server-appwrite",
+  "description": "MCP server for Appwrite - manage databases, users, functions, teams, and more",
+  "version": "0.2.1",
+  "author": "Appwrite",
+  "license": "MIT",
+  "homepage": "https://github.com/appwrite/mcp",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appwrite/mcp.git",
+    "source": "https://github.com/appwrite/mcp"
+  },
+  "packages": [
+    {
+      "version": "0.2.1",
+      "registryType": "pypi",
+      "identifier": "mcp-server-appwrite",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "capabilities": {
+    "tools": true
+  },
+  "command": {
+    "type": "pip",
+    "package": "mcp-server-appwrite",
+    "command": "mcp-server-appwrite"
+  },
+  "environment": {
+    "APPWRITE_PROJECT_ID": {
+      "description": "Your Appwrite project ID",
+      "required": true
+    },
+    "APPWRITE_API_KEY": {
+      "description": "Your Appwrite API key with necessary scopes",
+      "required": true
+    },
+    "APPWRITE_ENDPOINT": {
+      "description": "Your Appwrite endpoint URL (optional, defaults to cloud.appwrite.io)",
+      "required": false,
+      "default": "https://cloud.appwrite.io/v1"
+    }
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "appwrite",
+    "database",
+    "backend",
+    "api"
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Add server.json with proper MCP registry configuration
- Update GitHub Actions workflow to publish to both PyPI and MCP registry
- Include schema validation in CI pipeline

Purpose: to get listed on GitHub's MCP list: https://github.com/mcp

## Test Plan

Note:

After a release is created, it will automatically add Appwrite's MCP server to github.com/mcp's list. Our server will appear because the server.json file has all the metadata needed, the mcp publisher cli handles the registration, and registry pulls from the published server.json file. 

Then we can check the github actions to see if it runs successfully.

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)